### PR TITLE
Remove event_type

### DIFF
--- a/lib/hummingbird.ex
+++ b/lib/hummingbird.ex
@@ -71,7 +71,7 @@ defmodule Hummingbird do
     %Event{
       time: Event.now(),
       data: %{
-        name: "http_request",
+        # name: "http_request",
         conn: Helpers.sanitize(conn),
         caller: opts.caller,
         trace_id: conn.assigns[:trace_id],
@@ -80,7 +80,6 @@ defmodule Hummingbird do
         user_id: conn.assigns[:current_user][:user_id],
         route: conn.assigns[:request_path],
         service_name: opts.service_name
-        # kind: "span_event"
       }
     }
   end

--- a/lib/hummingbird.ex
+++ b/lib/hummingbird.ex
@@ -71,7 +71,6 @@ defmodule Hummingbird do
     %Event{
       time: Event.now(),
       data: %{
-        # name: "http_request",
         conn: Helpers.sanitize(conn),
         caller: opts.caller,
         trace_id: conn.assigns[:trace_id],
@@ -80,6 +79,15 @@ defmodule Hummingbird do
         user_id: conn.assigns[:current_user][:user_id],
         route: conn.assigns[:request_path],
         service_name: opts.service_name
+        # Does not appear important in the honeycomb.ui, leaving off
+        #
+        # name: "http_request",
+        #
+        # This is incorrect, but do not know how to programatically assign based on
+        # type.  My intuation is we would create a different build_ for that
+        # application.
+        #
+        # kind: "span_event"
       }
     }
   end

--- a/lib/hummingbird.ex
+++ b/lib/hummingbird.ex
@@ -79,8 +79,8 @@ defmodule Hummingbird do
         parent_id: conn.assigns[:parent_id],
         user_id: conn.assigns[:current_user][:user_id],
         route: conn.assigns[:request_path],
-        service_name: opts.service_name,
-        kind: "span_event"
+        service_name: opts.service_name
+        # kind: "span_event"
       }
     }
   end


### PR DESCRIPTION
As it creates unexpected issues in their UI per Molly @ honeycomb.

In dev, this did not express with the flapping waterfall trace.

Connects https://github.com/NFIBrokerage/technical_ideas/issues/97