### PR TITLE
Don't place output in our private repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
 
     - name: Publish library
-      run: mix hex.publish --yes --organization cuatro
+      # note, `--organization cuatro` is left off because we are publishing 
+      # run: mix hex.publish --yes --organization cuatro
+      run: mix hex.publish --yes
       if: startsWith(github.ref, 'refs/tags/v')
       env:
         MIX_ENV: dev


### PR DESCRIPTION
We pub'd automatically, but went to private repository.  Let's autopub for general use.