### PR TITLE
camel case some fields, lower-hex 16 character span ids

### DIFF
--- a/lib/hummingbird.ex
+++ b/lib/hummingbird.ex
@@ -76,8 +76,7 @@ defmodule Hummingbird do
         user_id: conn.assigns[:current_user][:user_id],
         route: conn.assigns[:request_path],
         serviceName: opts.service_name,
-        name: opts.service_name,
-        kind: "application"
+        name: opts.service_name
         # when applicable, add durationMs
         # ---
         # Does not appear important in the honeycomb.ui, leaving off

--- a/lib/hummingbird.ex
+++ b/lib/hummingbird.ex
@@ -40,7 +40,7 @@ defmodule Hummingbird do
         :span_id,
         # always set afterwards so as to accomodate the initial parent_id,
         # which should be nil
-        UUID.uuid4()
+        random_span_id()
       )
 
     [
@@ -70,12 +70,16 @@ defmodule Hummingbird do
       data: %{
         conn: Helpers.sanitize(conn),
         caller: opts.caller,
-        trace_id: conn.assigns[:trace_id],
-        span_id: conn.assigns[:span_id],
-        parent_id: conn.assigns[:parent_id],
+        traceId: conn.assigns[:trace_id],
+        id: conn.assigns[:span_id],
+        parentId: conn.assigns[:parent_id],
         user_id: conn.assigns[:current_user][:user_id],
         route: conn.assigns[:request_path],
-        service_name: opts.service_name
+        serviceName: opts.service_name,
+        name: opts.service_name,
+        kind: "application"
+        # when applicable, add durationMs
+        # ---
         # Does not appear important in the honeycomb.ui, leaving off
         #
         # name: "http_request",
@@ -121,5 +125,19 @@ defmodule Hummingbird do
       # fallback to this being an internal responsibility to assign a trace id
       conn.assigns[:trace_id]
     end
+  end
+
+  @doc """
+  Produces a random span ID.
+
+  Produces a string of lowercase hex-encoded characters of length 16 by
+  default.
+  """
+  def random_span_id(length \\ 16) do
+    length
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16()
+    |> binary_part(0, length)
+    |> String.downcase()
   end
 end

--- a/test/hummingbird_test.exs
+++ b/test/hummingbird_test.exs
@@ -157,4 +157,10 @@ defmodule HummingbirdTest do
       assert actual_opts === %{caller: "thisthing", service_name: "yourservice"}
     end
   end
+
+  test "random_span_id/0 only returns a string of downcase letters and numbers" do
+    for _n <- 1..100 do
+      assert Regex.match?(~r/^[a-z0-9]{16}$/, Hummingbird.random_span_id())
+    end
+  end
 end


### PR DESCRIPTION
closes #18 

- `trace_id` -> `traceId`
- `span_id` -> `id`
- `parent_id` -> `parentId`
- `service_name` -> `serviceName`

and now the span ids are 16 digit lower hex strings like `532eac39cbc1a687`