### PR TITLE
phoenix instrumentation

### DIFF
--- a/lib/hummingbird.ex
+++ b/lib/hummingbird.ex
@@ -71,7 +71,7 @@ defmodule Hummingbird do
         route: conn.assigns[:request_path],
         serviceName: opts.service_name,
         durationMs: conn.assigns[:request_duration],
-        http: metadata_from_conn(conn)
+        http: http_metadata_from_conn(conn)
         # This is incorrect, but do not know how to programatically assign based on
         # type.  My intuation is we would create a different build_ for that
         # application.
@@ -137,7 +137,7 @@ defmodule Hummingbird do
   """
   def random_trace_id, do: random_span_id(32)
 
-  defp metadata_from_conn(%Plug.Conn{} = conn) do
+  defp http_metadata_from_conn(%Plug.Conn{} = conn) do
     scheme = Atom.to_string(conn.scheme)
 
     url =

--- a/lib/hummingbird/instrumentation.ex
+++ b/lib/hummingbird/instrumentation.ex
@@ -1,6 +1,19 @@
 defmodule Hummingbird.Instrumentation do
   @moduledoc """
   Plug instrumentation for an endpoint which records durations
+
+  Configured with the same options as the `Hummingbird` plug.
+
+  ## Example
+
+      defmodule MyAppWeb.Endpoint do
+        use Phoenix.Endpoint, otp_app: :my_app
+
+        use Hummingbird.Instrumentation,
+          service_name: "my_app",
+          caller: __MODULE__
+
+        ..
   """
 
   defmacro __using__(opts) do

--- a/lib/hummingbird/instrumentation.ex
+++ b/lib/hummingbird/instrumentation.ex
@@ -26,7 +26,7 @@ defmodule Hummingbird.Instrumentation do
         {time, conn_after_execution} = :timer.tc(fn -> super(conn_before_execution, opts) end)
 
         conn_after_execution
-        |> assign(:request_duration, System.convert_time_unit(time, :native, :millisecond))
+        |> assign(:request_duration_native, time)
         |> Hummingbird.send_span(unquote(opts) |> Hummingbird.init())
 
         conn_after_execution

--- a/lib/hummingbird/instrumentation.ex
+++ b/lib/hummingbird/instrumentation.ex
@@ -1,0 +1,25 @@
+defmodule Hummingbird.Instrumentation do
+  @moduledoc """
+  Plug instrumentation for an endpoint which records durations
+  """
+
+  defmacro __using__(opts) do
+    quote do
+      # N.B. in this context, I'm saying execution to mean a run through the
+      # phoenix pipeline (endpoint -> router -> controllers, etc..)
+      def call(conn, opts) do
+        conn_before_execution = Hummingbird.set_trace_info(conn)
+
+        {time, conn_after_execution} = :timer.tc(fn -> super(conn_before_execution, opts) end)
+
+        conn_after_execution
+        |> assign(:request_duration, System.convert_time_unit(time, :native, :millisecond))
+        |> Hummingbird.send_span(unquote(opts) |> Hummingbird.init())
+
+        conn_after_execution
+      end
+
+      defoverridable call: 2
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,6 @@ defmodule Hummingbird.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         coveralls: :test,
@@ -30,7 +29,6 @@ defmodule Hummingbird.MixProject do
         dialyzer: :test,
         bless: :test
       ],
-      dialyzer: [ignore_warnings: ".dialyzer.ignore_warnings"],
       test_coverage: [tool: ExCoveralls],
       package: package(),
       description: description(),
@@ -74,32 +72,9 @@ defmodule Hummingbird.MixProject do
       {:plug, "~> 1.7"},
       {:elixir_uuid, "~> 1.2"},
       {:opencensus_honeycomb, "~> 0.2.1"},
+      {:bless, "~> 1.0"},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.4", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.11", only: :test}
     ]
-  end
-
-  defp aliases do
-    [
-      bless: [&bless/1]
-    ]
-  end
-
-  defp bless(_) do
-    [
-      {"compile", ["--force", "--warnings-as-errors"]},
-      {"coveralls.html", []},
-      {"format", ["--check-formatted"]},
-      {"credo", []},
-      {"dialyzer", []}
-    ]
-    |> Enum.each(fn {task, args} ->
-      [:cyan, "Running #{task} with args #{inspect(args)}"]
-      |> IO.ANSI.format()
-      |> IO.puts()
-
-      Mix.Task.run(task, args)
-    end)
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "bless": {:hex, :bless, "1.0.0", "7bf593b90e50dd08ce1245a3087a71e44c400ad060ed39b863c7bdb2639d2e4d", [:mix], [], "hexpm", "5c1d375a44313c1d85bf151ede054145464b9a3056fb5ee739b3721302521017"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "805abd97539caf89ec6d4732c91e62ba9da0cda51ac462380bbd28ee697a8c42"},
   "counters": {:hex, :counters, "0.2.1", "aa3d97e88f92573488987193d0f48efce0f3b2cd1443bf4ee760bc7f99322f0c", [:mix, :rebar3], [], "hexpm", "a020c714992f7db89178d27e1f39909e5d77da3b80daa4d6015877ed0c94b8ab"},


### PR DESCRIPTION
connects #18 
closes #14 

follows the same pattern as appsignal's instrumentation. with a little more work, we could also `try/catch` errors and send those as spans as well

I've also taken the liberty of:

- adding the http field on there with http metadata. this metadata matches istio's output
- make trace ids as 32 character lower hex strings instead of UUIDs
- change the caller field to name (also matches the istio data we're getting)