### PR TITLE
cleanse most of assigns out of the conn

### DIFF
--- a/lib/hummingbird/impl.ex
+++ b/lib/hummingbird/impl.ex
@@ -12,8 +12,7 @@ defmodule Hummingbird.Impl do
       conn
       | private: nil,
         secret_key_base: nil,
-        assigns: nil,
-        selected_assigns: Map.take(conn.assigns, [:current_user, :admin_user])
+        assigns: Map.take(conn.assigns, [:current_user, :admin_user])
     }
   end
 

--- a/lib/hummingbird/impl.ex
+++ b/lib/hummingbird/impl.ex
@@ -12,7 +12,8 @@ defmodule Hummingbird.Impl do
       conn
       | private: nil,
         secret_key_base: nil,
-        assigns: Map.take(conn.assigns, [:current_user, :admin_user])
+        assigns: nil,
+        selected_assigns: Map.take(conn.assigns, [:current_user, :admin_user])
     }
   end
 

--- a/lib/hummingbird/impl.ex
+++ b/lib/hummingbird/impl.ex
@@ -11,7 +11,8 @@ defmodule Hummingbird.Impl do
     %{
       conn
       | private: nil,
-        secret_key_base: nil
+        secret_key_base: nil,
+        assigns: Map.take(conn.assigns, [:current_user, :admin_user])
     }
   end
 


### PR DESCRIPTION
from what I can see in the dataset page, we're losing most of our columns (~200) to a big list of `charge_codes` being in assigns. then there's a bunch of other stuff like `load.pickup_city` and other misc

I think the only thing we really need is the current_user