### PR TITLE
refactor GenServer.cast/2 into a task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 - [UNRELEASED]
+
+### Changed
+
+- GenServer casting pattern refactored to perform the sending of the honeycomb
+  event in the process which emitted the event
+    - for phoenix telemetry events, this means that the cowboy/phoenix process
+      uploads the event to honeycomb, which prevents a centralized GenServer
+      from hoarding memory if there are many requests to a Phoenix endpoint
+
+## 0.1.1 - 2021-06-18
+
+### Changed
+
+- the `conn.params` field is now JSON-encoded
+
+## 0.1.0 - 2021-06-15
+
+### Changed
+
+- `:opencensus_honeycomb` dependency updated to `~> 0.3`

--- a/lib/hummingbird/telemetry.ex
+++ b/lib/hummingbird/telemetry.ex
@@ -12,30 +12,23 @@ defmodule Hummingbird.Telemetry do
       ]
   """
 
-  use GenServer
+  use Task
 
   require Logger
 
   @doc false
   def start_link(_args) do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    Task.start_link(__MODULE__, :attach, [])
   end
 
   @doc false
-  def init(state) do
-    {:ok, state, {:continue, :telemetry_attach}}
-  end
-
-  @doc false
-  def handle_continue(:telemetry_attach, state) do
+  def attach do
     :telemetry.attach(
       "hummingbird-phoenix-endpoint-handler",
       [:phoenix, :endpoint, :stop],
       &handle_event/4,
       []
     )
-
-    {:noreply, state}
   end
 
   @doc false
@@ -43,17 +36,12 @@ defmodule Hummingbird.Telemetry do
         [:phoenix, :endpoint, :stop],
         %{duration: duration_native},
         %{conn: conn},
-        _config
+        state
       ) do
-    GenServer.cast(__MODULE__, {conn, duration_native})
-  end
-
-  @doc false
-  def handle_cast({conn, duration_native}, state) do
     conn
     |> Plug.Conn.assign(:request_duration_native, duration_native)
     |> Hummingbird.send_spans()
 
-    {:noreply, state}
+    state
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Hummingbird.MixProject do
   # a special module attribute that recompiles if targeted file has changed
   @external_resource @version_file
 
-  @version (case Regex.run(~r/^v([\d\.]+)/, File.read!(@version_file), capture: :all_but_first) do
+  @version (case Regex.run(~r/^v([\d\.\w-]+)/, File.read!(@version_file), capture: :all_but_first) do
               [version] -> version
               nil -> "0.0.0"
             end)


### PR DESCRIPTION
this GenServer we cast/2 to is accumulating a huge amount of memory and I suspect needlessly

this PR refactors hummingbird to not use a process for the sending of events: instead the sending of events is done in the cowboy process after the phoenix endpoint call is done

I think this should result in no extra latency per http request but should reduce the memory footprint of this library